### PR TITLE
Admin design

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -224,3 +224,10 @@ img.funder-logo {
   -webkit-justify-content: center;
   justify-content: center;
 }
+
+// Override default gray to improve the look of circular avatars
+// with a transparent image margin.
+
+div.image {
+  background-color: #FFFFFF !important;
+}

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -7,7 +7,10 @@
 module Admin
   class ApplicationController < Administrate::ApplicationController
 
-    http_basic_authenticate_with name: ENV.fetch("ADMIN_NAME", 'admin'), password: ENV.fetch("ADMIN_PASSWORD", 'password')
+    helper ApplicationHelper # Include Markdown renderer
+
+    http_basic_authenticate_with name: ENV.fetch('ADMIN_NAME', 'admin'),
+      password: ENV.fetch('ADMIN_PASSWORD', 'password')
 
     # Override this value to specify the number of elements to display at a time
     # on index pages. Defaults to 20.

--- a/app/dashboards/staff_dashboard.rb
+++ b/app/dashboards/staff_dashboard.rb
@@ -8,12 +8,12 @@ class StaffDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    id: Field::Number,
-    name: Field::String,
-    avatar: PaperclipField,
-    bio: Field::Text,
-    position: Field::Number,
-    role: Field::String,
+    id:         Field::Number,
+    name:       Field::String,
+    avatar:     PaperclipField,
+    bio:        Field::Text,
+    position:   Field::Number,
+    role:       Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     group: Field::BelongsTo,
@@ -28,6 +28,7 @@ class StaffDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :id,
     :name,
+    :email,
     :avatar,
   ].freeze
 
@@ -36,6 +37,7 @@ class StaffDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :id,
     :name,
+    :email,
     :avatar,
     :bio,
     :created_at,
@@ -59,7 +61,7 @@ class StaffDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how staffs are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(staff)
-  #   "Staff ##{staff.id}"
-  # end
+  def display_resource(staff)
+    staff.name
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,9 @@
+require 'markdownify'
+
 module ApplicationHelper
-  def markdown(text)
-    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
-    no_intra_emphasis: true, 
-    fenced_code_blocks: true,   
-    autolink: true,
-    disable_indented_code_blocks: true)
-    return markdown.render(text).html_safe
+
+  def markdown(source)
+    Markdownify.render(source)
   end
+
 end

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -40,7 +40,7 @@
           = group
         .ui.four.stackable.cards
           - @staff[group].each do |staff|
-            .card{"data-html": "<div class='content'>#{staff.bio}</div>", "data-position": "top center", class: ("bio-popup" unless staff.bio.empty? )}
+            .card{"data-html": "<div class='content'>#{markdown staff.bio}</div>", "data-position": "top center", class: ("bio-popup" unless staff.bio.empty? )}
               .image
                 %img{src: staff.avatar.url(:thumbnail), class: ""}
               .content

--- a/app/views/fields/paperclip_field/_show.html.erb
+++ b/app/views/fields/paperclip_field/_show.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag field.url %>
+<%= image_tag field.thumbnail %>

--- a/app/views/fields/text/_show.html.erb
+++ b/app/views/fields/text/_show.html.erb
@@ -16,4 +16,6 @@ whitespace preserved.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Text
 %>
 
-<span class="preserve-whitespace"><%= field.data %></span>
+<span class="preserve-whitespace">
+  <%= markdown field.data %>
+</span>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 20160818193557) do
     t.string   "screenshot"
     t.string   "icon"
     t.string   "url"
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.string   "preview_file_name"
     t.string   "preview_content_type"
     t.integer  "preview_file_size"
@@ -50,17 +52,21 @@ ActiveRecord::Schema.define(version: 20160818193557) do
   end
 
   create_table "services", force: :cascade do |t|
-    t.string  "title"
-    t.text    "desc"
-    t.integer "group_id"
-    t.integer "position"
+    t.string   "title"
+    t.text     "desc"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer  "group_id"
+    t.integer  "position"
   end
 
   create_table "staff", force: :cascade do |t|
-    t.string  "name"
-    t.string  "email"
-    t.text    "bio"
-    t.integer "group_id"
+    t.string   "name"
+    t.string   "email"
+    t.text     "bio"
+    t.integer  "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "staffs", force: :cascade do |t|
@@ -83,6 +89,8 @@ ActiveRecord::Schema.define(version: 20160818193557) do
     t.string   "screenshot"
     t.string   "url"
     t.text     "body"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.string   "screenshot_file_name"
     t.string   "screenshot_content_type"
     t.integer  "screenshot_file_size"

--- a/lib/markdownify.rb
+++ b/lib/markdownify.rb
@@ -1,0 +1,25 @@
+module Markdownify
+
+  def self.render(source)
+    markdown.render(source).html_safe
+  end
+
+  private
+
+  def self.markdown
+    @markdown ||= Redcarpet::Markdown.new(renderer, options)
+  end
+
+  def self.renderer
+    Redcarpet::Render::HTML
+  end
+
+  def self.options
+    {
+      autolink: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      disable_indented_code_blocks: true
+    }
+  end
+end


### PR DESCRIPTION
- Makes the avatar a thumbnail
- Removes gray background from transparent-surrounded round avatars
- Render Markdown in admin console preview.
