### PR TITLE
Fix text wrapping

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -239,3 +239,9 @@ img.funder-logo {
 div.image {
   background-color: #FFFFFF !important;
 }
+
+// Override section link to not wrap text so aggressively
+
+.grid-row.big-menu-group a {
+  padding: 1rem 4rem 1rem 1rem;
+}

--- a/app/views/groups/_group.html.haml
+++ b/app/views/groups/_group.html.haml
@@ -1,0 +1,11 @@
+.menu-item
+  %a{ href: '#' }
+    %h3
+      = group.title
+    %p
+      = group.tagline
+    %p
+      = link_to 'Learn More »', group, class: 'menu-group-link'
+  .big-menu-group.grid-row
+    - group.services.each do |service|
+      = link_to service.title, service, class: 'one-third'

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -44,19 +44,7 @@
     %h2 Services
     .grid-row
       %nav.big-menu
-        - @groups.each do |group|
-          .menu-item
-            %a{href: "#"}
-              %h3
-                = group.title
-              %p
-                = group.tagline
-              %p
-                =link_to("Learn More »", group, class: "menu-group-link")
-            .big-menu-group.grid-row
-              - group.services.each do |service|
-                = link_to(service, class: 'one-third') do
-                  = service.title
+        = render partial: 'groups/group', collection: @groups, as: :group
 
 %section#section-2.section
   .container


### PR DESCRIPTION
Why:

Service boxes on the homepage had high padding, so text was wrapping and
flowing outside of the box.

This decreases the padding-right by overriding padding set by the base
styles.

In the process, I also split out the group display as a partial.
